### PR TITLE
Dockerfile improvement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+docker/
+obligator
+obligator_db.sqlite
+obligator_storage.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ docker/
 obligator
 obligator_db.sqlite
 obligator_storage.json
+.git/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,37 @@
-FROM alpine:3.18
+FROM golang:1.21 as builder
 
-RUN apk add --no-cache curl
+# Set the working directory inside the container
+WORKDIR /app
 
-COPY ./obligator /obligator/obligator
+# Copy the Go Modules manifests
+COPY go.mod go.sum ./
+# Download Go module dependencies
+RUN go mod download
+
+# Copy the source code into the container
+COPY . .
+
+# Those linker flag enables us to statically link sqlite
+RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o obligator/obligator .
+
+FROM debian:bullseye-slim
+
+WORKDIR /obligator
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY --from=builder /app/obligator /obligator
+
+COPY --from=builder /etc/passwd /etc/passwd
+
+RUN addgroup --gid 1001 --system appuser && adduser --system --uid 1001 --ingroup appuser appuser
+RUN chown -R appuser:appuser /obligator
 
 VOLUME ["/data"]
 
 VOLUME ["/api"]
+
+USER 1001
 
 EXPOSE 1616
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,8 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
   -o obligator/obligator \
   ./cmd/obligator/
 
+RUN strip obligator/obligator
+
 FROM docker.io/alpine:3.18
 
 WORKDIR /obligator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,13 @@ RUN go mod download
 # Copy the source code into the container
 COPY . .
 
-# Those linker flag enables us to statically link sqlite
-RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o obligator/obligator .
+# Those linker flags statically link sqlite.
+# Check out https://www.arp242.net/static-go.html to understand these build parameters.
+RUN CGO_ENABLED=1 GOOS=linux go build \
+  -a \
+  -ldflags '-linkmode external -extldflags "-static"' \
+  -tags sqlite_omit_load_extension,netgo \
+  -o obligator/obligator .
 
 FROM docker.io/alpine:3.18
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,8 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
   -a \
   -ldflags '-linkmode external -extldflags "-static"' \
   -tags sqlite_omit_load_extension,netgo \
-  -o obligator/obligator .
+  -o obligator/obligator \
+  ./cmd/obligator/
 
 FROM docker.io/alpine:3.18
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,15 +14,16 @@ COPY . .
 # Those linker flag enables us to statically link sqlite
 RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o obligator/obligator .
 
-FROM docker.io/debian:bullseye-slim
+FROM docker.io/alpine:3.18
 
 WORKDIR /obligator
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apk --no-cache add ca-certificates && \
+    addgroup -S appuser -g 1001 && \
+    adduser -S -G appuser -u 1001 appuser
 
 COPY --from=builder /app/obligator /obligator
 
-RUN addgroup --gid 1001 --system appuser && adduser --system --uid 1001 --ingroup appuser appuser
 RUN chown -R appuser:appuser /obligator
 
 VOLUME ["/data"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM docker.io/golang:1.21 as builder
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -14,15 +14,13 @@ COPY . .
 # Those linker flag enables us to statically link sqlite
 RUN CGO_ENABLED=1 GOOS=linux go build -a -ldflags '-linkmode external -extldflags "-static"' -o obligator/obligator .
 
-FROM debian:bullseye-slim
+FROM docker.io/debian:bullseye-slim
 
 WORKDIR /obligator
 
 RUN apt-get update && apt-get install -y ca-certificates
 
 COPY --from=builder /app/obligator /obligator
-
-COPY --from=builder /etc/passwd /etc/passwd
 
 RUN addgroup --gid 1001 --system appuser && adduser --system --uid 1001 --ingroup appuser appuser
 RUN chown -R appuser:appuser /obligator


### PR DESCRIPTION
- Improves docker image security: use non root user, as numeric user id.
- Use fully qualified image url in `from` clause (so podman can build it too). 
- Use builder pattern so dockerfile is self contained now. 
- a `.dockerignore` file.

Thank you for making this software 🙂 .  I am enjoying using it.