### PR TITLE
Fix blank no-account page

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,9 +277,13 @@ func main() {
 
 	mux.HandleFunc("/no-account", func(w http.ResponseWriter, r *http.Request) {
 		data := struct {
-			URL string
+			URL         string
+			RootUri     string
+			DisplayName string
 		}{
-			URL: fmt.Sprintf("/auth?%s", r.URL.RawQuery),
+			URL:         fmt.Sprintf("/auth?%s", r.URL.RawQuery),
+			RootUri:     storage.GetRootUri(),
+			DisplayName: storage.GetDisplayName(),
 		}
 
 		err = tmpl.ExecuteTemplate(w, "no-account.html", data)


### PR DESCRIPTION
Currently the no-account page always throw 500, it can be reproduced by visiting: https://lastlogin.io/no-account

This PR fixes that. 