### PR TITLE
Make email authentication optional

### DIFF
--- a/add_identity_email.go
+++ b/add_identity_email.go
@@ -539,7 +539,10 @@ func (h *AddIdentityEmailHandler) StartEmailValidation(email, rootUri, magicLink
 	fromEmail := smtpConfig.Sender
 	emailBody := fmt.Sprintf(bodyTemplate, fromText, fromEmail, email, smtpConfig.SenderName, email, magicLink)
 
-	emailAuth := smtp.PlainAuth("", smtpConfig.Username, smtpConfig.Password, smtpConfig.Server)
+	emailAuth := smtp.Auth(nil)
+	if smtpConfig.Username != "" && smtpConfig.Password != "" {
+		emailAuth = smtp.PlainAuth("", smtpConfig.Username, smtpConfig.Password, smtpConfig.Server)
+	}
 	srv := fmt.Sprintf("%s:%d", smtpConfig.Server, smtpConfig.Port)
 	msg := []byte(emailBody)
 	err = smtp.SendMail(srv, emailAuth, fromEmail, []string{email}, msg)


### PR DESCRIPTION
When running obligator on a server which already has an SMTP service. This service can sometimes not allow authentication. For these situations it makes sense to disable authentication when neither a username nor password is specified.

This is probably the first Go code I've written in about 6 years since I spent 20 minutes on the go tour, I apologise if it's completely wrong. Just let me know, and I'll try to figure out why myself. Alternatively, if you feel like you like the feature but don't feel like trying to teach me enough Go for me to contribute it then feel free to ignore this PR and contribute a more correct implementation, I won't feel offended.